### PR TITLE
Potential fix for code scanning alert no. 1: Replacement of a substring with itself

### DIFF
--- a/static/js/script1.js
+++ b/static/js/script1.js
@@ -340,8 +340,8 @@ function transformText(text) {
     // Add proper sentence spacing
     .replace(/([.!?])\s*([A-Z])/g, "$1 $2")
     // Fix quotes
-    .replace(/"/g, '"')
-    .replace(/"/g, '"')
+    
+    
     .replace(/'/g, '"')
     .replace(/'/g, ":")
     // Capitalize first letter of sentences


### PR DESCRIPTION
Potential fix for [https://github.com/ZakisCodes/DraftFlow/security/code-scanning/1](https://github.com/ZakisCodes/DraftFlow/security/code-scanning/1)

To fix the issue, we need to remove the redundant `.replace(/"/g, '"')` operation on line 343. If the intention was to escape double quotes, the replacement string should be corrected to `'\\"'`. However, based on the context of the code, it seems that the transformation logic does not require escaping double quotes, as the subsequent lines handle quotes differently. Therefore, the best fix is to remove the redundant line entirely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
